### PR TITLE
Update game.info

### DIFF
--- a/backends/platform/3ds/app/game.info
+++ b/backends/platform/3ds/app/game.info
@@ -61,7 +61,7 @@ else ifeq ($(GAME), QUEEN)
 	APP_UNIQUE_ID   := 0xFF32C
 
 else ifeq ($(GAME), RIVEN)
-	APP_TITLE       := Riven: A Sequel to Myst
+	APP_TITLE       := Riven: The Sequel to Myst
 	APP_UNIQUE_ID   := 0xFF32D
 
 else ifeq ($(GAME), SAMNMAX)


### PR DESCRIPTION
Typo: correct "Riven: A Sequel to Myst" to "Riven: The Sequel to Myst"